### PR TITLE
Erreur de récupération de l'ip

### DIFF
--- a/app/class/ip.php
+++ b/app/class/ip.php
@@ -11,13 +11,15 @@
 		 * @return string
 		 */
 		public static function getIp($server) {
-			if (!empty($server['HTTP_CLIENT_IP'])) {
+			// Cette IP (via REMOTE_ADDR) est plus sûr, contrairement aux 2 autres (HTTP_CLIENT_IP et HTTP_X_FORWARDED_FOR) 
+			// qui peuvent être injecté via les entetes HTTP et ne sont donc pas fiable du tout ! (A éviter).
+			if (!empty( $server['REMOTE_ADDR'])) {
+			    $ip = $server['REMOTE_ADDR'];
+			} elseif (!empty($server['HTTP_CLIENT_IP'])) {
 			    $ip = $server['HTTP_CLIENT_IP'];
 			} elseif (!empty($server['HTTP_X_FORWARDED_FOR'])) {
 			    $ip = $server['HTTP_X_FORWARDED_FOR'];
-			} else {
-			    $ip = $server['REMOTE_ADDR'];
-			}
+			} 
 			return ip;
 		}
 


### PR DESCRIPTION
Il est important de savoir que toute variables $_SERVER commençant par HTTP_ , n'est pas fiable car elles proviennent des entêtes HTTP (envoyé de base par le navigateur) et ne sont donc pas fiable (comme HTTP_USER_AGENT).